### PR TITLE
Fix typo

### DIFF
--- a/basicNotation.md
+++ b/basicNotation.md
@@ -27,7 +27,7 @@ The grand staff consists of two staves, one that uses a treble clef, and one tha
 
 ### Ledger lines
 
-When the music's range exceeds what can be written on the staff, extra lines are drawn so that we can still clearly read the pitch. These extra lines are called *ledger lines.* In the example below, From Haydn's Piano Sonata in G (Hob. XVI: 39), Ab5 occurs just above the treble staff in the right hand, and G3 and B3 occur just below the treble staff in the left hand.
+When the music's range exceeds what can be written on the staff, extra lines are drawn so that we can still clearly read the pitch. These extra lines are called *ledger lines.* In the example below, From Haydn's Piano Sonata in G (Hob. XVI: 39), Ab5 occurs just above the treble staff in the right hand, and G3 and B3 occur just below the bass staff in the left hand.
 
 <img src ="Graphics/ledgerLines.png" width="80%" height="80%">
 


### PR DESCRIPTION
In the graphic, the ledger lines for G3 & B3 are clearly below the bass staff.